### PR TITLE
Add multi-language CI with unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  go:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: go-cli
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go-cli/go.mod
+      - run: go test ./...
+
+  rust:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: rust-cli
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - run: cargo test --verbose
+
+  dart:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: dart-cli
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1
+      - run: dart pub get
+      - run: dart test
+
+  flutter:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: flutter-gui
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter pub get
+      - run: flutter test
+
+  java:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: NetBeans
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - run: mvn -B test

--- a/NetBeans/pom.xml
+++ b/NetBeans/pom.xml
@@ -80,6 +80,12 @@
             <artifactId>org-netbeans-modules-settings</artifactId>
             <version>RELEASE220</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/NetBeans/src/test/java/me/davidcanhelp/chatgpt/ChatWindowTopComponentTest.java
+++ b/NetBeans/src/test/java/me/davidcanhelp/chatgpt/ChatWindowTopComponentTest.java
@@ -1,0 +1,35 @@
+package me.davidcanhelp.chatgpt;
+
+import org.junit.Test;
+import org.junit.Assert;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class ChatWindowTopComponentTest {
+    @Test
+    public void testReadApiKeyFromFileMissing() throws Exception {
+        ChatWindowTopComponent comp = new ChatWindowTopComponent();
+        String orig = System.getProperty("user.home");
+        Path tmp = Files.createTempDirectory("testhome");
+        System.setProperty("user.home", tmp.toString());
+        try {
+            Method m = ChatWindowTopComponent.class.getDeclaredMethod("readApiKeyFromFile");
+            m.setAccessible(true);
+            Assert.assertThrows(IOException.class, () -> {
+                try {
+                    m.invoke(comp);
+                } catch (InvocationTargetException e) {
+                    if (e.getCause() instanceof IOException) {
+                        throw (IOException) e.getCause();
+                    }
+                    throw new RuntimeException(e.getCause());
+                }
+            });
+        } finally {
+            System.setProperty("user.home", orig);
+        }
+    }
+}

--- a/dart-cli/test/dart_cli_test.dart
+++ b/dart-cli/test/dart_cli_test.dart
@@ -1,0 +1,30 @@
+import 'dart:io';
+import 'package:test/test.dart';
+import '../bin/dart_cli.dart';
+
+void main() {
+  group('storage', () {
+    test('save and load', () async {
+      var dir = Directory.systemTemp.createTempSync();
+      var prev = Directory.current;
+      Directory.current = dir;
+      var items = [Item(id: 1, prompt: 'p', response: 'r')];
+      await saveItems(items);
+      var loaded = await loadItems();
+      expect(loaded.length, 1);
+      expect(loaded.first.prompt, 'p');
+      Directory.current = prev;
+    });
+
+    test('delete item', () {
+      var items = [
+        Item(id: 1, prompt: 'a', response: 'b'),
+        Item(id: 2, prompt: 'c', response: 'd')
+      ];
+      deleteItem(1, items);
+      expect(items.length, 1);
+      expect(items.first.id, 2);
+      expect(() => deleteItem(3, items), throwsException);
+    });
+  });
+}

--- a/flutter-gui/test/item_test.dart
+++ b/flutter-gui/test/item_test.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:chatgpt_flutter_gui/main.dart';
+
+void main() {
+  test('item serialization', () {
+    final item = Item(id: 1, prompt: 'p', response: 'r');
+    final map = item.toJson();
+    expect(map['id'], 1);
+    final back = Item.fromJson(map);
+    expect(back.prompt, 'p');
+  });
+}

--- a/go-cli/main_test.go
+++ b/go-cli/main_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+    "os"
+    "reflect"
+    "testing"
+)
+
+func TestSaveAndLoadItems(t *testing.T) {
+    dir := t.TempDir()
+    prev, _ := os.Getwd()
+    os.Chdir(dir)
+    defer os.Chdir(prev)
+
+    items := []Item{{ID: 1, Prompt: "p", Response: "r"}}
+    if err := saveItems(items); err != nil {
+        t.Fatal(err)
+    }
+    loaded, err := loadItems()
+    if err != nil {
+        t.Fatal(err)
+    }
+    if !reflect.DeepEqual(items, loaded) {
+        t.Errorf("expected %v got %v", items, loaded)
+    }
+}
+
+func TestDeleteItem(t *testing.T) {
+    items := []Item{{ID: 1, Prompt: "a", Response: "b"}, {ID: 2, Prompt: "c", Response: "d"}}
+    out, err := deleteItem(1, items)
+    if err != nil {
+        t.Fatal(err)
+    }
+    if len(out) != 1 || out[0].ID != 2 {
+        t.Fatalf("unexpected result: %v", out)
+    }
+    if _, err := deleteItem(3, items); err == nil {
+        t.Fatal("expected error")
+    }
+}

--- a/rust-cli/Cargo.toml
+++ b/rust-cli/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2024"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/rust-cli/src/main.rs
+++ b/rust-cli/src/main.rs
@@ -158,3 +158,36 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+
+    #[test]
+    fn test_save_and_load() {
+        let dir = tempfile::tempdir().unwrap();
+        let prev = env::current_dir().unwrap();
+        env::set_current_dir(&dir).unwrap();
+
+        let items = vec![Item { id: 1, prompt: "p".into(), response: "r".into() }];
+        save_items(&items).unwrap();
+        let loaded = load_items().unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].prompt, "p");
+
+        env::set_current_dir(prev).unwrap();
+    }
+
+    #[test]
+    fn test_delete_item() {
+        let mut items = vec![
+            Item { id: 1, prompt: "a".into(), response: "b".into() },
+            Item { id: 2, prompt: "c".into(), response: "d".into() },
+        ];
+        delete_item(1, &mut items).unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].id, 2);
+        assert!(delete_item(3, &mut items).is_err());
+    }
+}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to test Java, Go, Rust, Dart and Flutter projects
- provide basic unit tests for all language implementations
- enable JUnit tests for the NetBeans plugin

## Testing
- `go test ./...` in `go-cli`
- `cargo test` *(failed: could not download crates)*