### PR TITLE
Refactor CLI tests and apply formatting

### DIFF
--- a/go-cli/main_test.go
+++ b/go-cli/main_test.go
@@ -6,35 +6,39 @@ import (
     "testing"
 )
 
-func TestSaveAndLoadItems(t *testing.T) {
+func TestSaveAndLoadHistory(t *testing.T) {
     dir := t.TempDir()
     prev, _ := os.Getwd()
     os.Chdir(dir)
     defer os.Chdir(prev)
 
-    items := []Item{{ID: 1, Prompt: "p", Response: "r"}}
-    if err := saveItems(items); err != nil {
+    msgs := []Message{{Role: "user", Content: "hello"}}
+    if err := saveHistory(msgs); err != nil {
         t.Fatal(err)
     }
-    loaded, err := loadItems()
+    loaded, err := loadHistory()
     if err != nil {
         t.Fatal(err)
     }
-    if !reflect.DeepEqual(items, loaded) {
-        t.Errorf("expected %v got %v", items, loaded)
+    if !reflect.DeepEqual(msgs, loaded) {
+        t.Errorf("expected %v got %v", msgs, loaded)
     }
 }
 
-func TestDeleteItem(t *testing.T) {
-    items := []Item{{ID: 1, Prompt: "a", Response: "b"}, {ID: 2, Prompt: "c", Response: "d"}}
-    out, err := deleteItem(1, items)
-    if err != nil {
+func TestClearHistory(t *testing.T) {
+    dir := t.TempDir()
+    prev, _ := os.Getwd()
+    os.Chdir(dir)
+    defer os.Chdir(prev)
+
+    msgs := []Message{{Role: "user", Content: "bye"}}
+    if err := saveHistory(msgs); err != nil {
         t.Fatal(err)
     }
-    if len(out) != 1 || out[0].ID != 2 {
-        t.Fatalf("unexpected result: %v", out)
+    if err := clearHistory(); err != nil {
+        t.Fatal(err)
     }
-    if _, err := deleteItem(3, items); err == nil {
-        t.Fatal("expected error")
+    if _, err := os.Stat(historyFile); !os.IsNotExist(err) {
+        t.Fatalf("history file should be removed")
     }
 }

--- a/rust-cli/src/main.rs
+++ b/rust-cli/src/main.rs
@@ -132,29 +132,30 @@ mod tests {
     use std::env;
 
     #[test]
-    fn test_save_and_load() {
+    fn save_and_load_history() {
         let dir = tempfile::tempdir().unwrap();
         let prev = env::current_dir().unwrap();
         env::set_current_dir(&dir).unwrap();
 
-        let items = vec![Item { id: 1, prompt: "p".into(), response: "r".into() }];
-        save_items(&items).unwrap();
-        let loaded = load_items().unwrap();
-        assert_eq!(loaded.len(), 1);
-        assert_eq!(loaded[0].prompt, "p");
+        let msgs = vec![Message { role: "user".into(), content: "hi".into() }];
+        save_history(&msgs).unwrap();
+        let loaded = load_history().unwrap();
+        assert_eq!(msgs, loaded);
 
         env::set_current_dir(prev).unwrap();
     }
 
     #[test]
-    fn test_delete_item() {
-        let mut items = vec![
-            Item { id: 1, prompt: "a".into(), response: "b".into() },
-            Item { id: 2, prompt: "c".into(), response: "d".into() },
-        ];
-        delete_item(1, &mut items).unwrap();
-        assert_eq!(items.len(), 1);
-        assert_eq!(items[0].id, 2);
-        assert!(delete_item(3, &mut items).is_err());
+    fn clear_history() {
+        let dir = tempfile::tempdir().unwrap();
+        let prev = env::current_dir().unwrap();
+        env::set_current_dir(&dir).unwrap();
+
+        let msgs = vec![Message { role: "user".into(), content: "bye".into() }];
+        save_history(&msgs).unwrap();
+        clear_history().unwrap();
+        assert!(!std::path::Path::new(HISTORY_FILE).exists());
+
+        env::set_current_dir(prev).unwrap();
     }
 }


### PR DESCRIPTION
## Summary
- reformat Go CLI with spaces instead of tabs
- replace stale Go tests with history-based checks
- update Rust tests to use current history helpers

## Testing
- `go test`
- ❌ `cargo test --offline` *(fails: no matching package named `reqwest` found)*