### PR TITLE
Cleanup and add test guidelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,12 @@ hs_err_pid*
 replay_pid*
 # Rust build output
 rust-cli/target/
+# Build artifacts
+NetBeans/nbbuild/
+NetBeans/build/
+NetBeans/target/
+flutter-gui/build/
+flutter-gui/.dart_tool/
+dart-cli/.dart_tool/
+# CLI history files
+*/history.json

--- a/README.md
+++ b/README.md
@@ -9,3 +9,14 @@ This repository contains multiple implementations that interact with the OpenAI 
 - `rust-cli/` – A command line interface written in Rust.
 
 All CLI implementations share the same workflow: start an interactive `chat` session, inspect `history`, or `clear` the stored conversation. Each subfolder may provide additional documentation.
+
+## Testing
+
+Each subproject provides unit tests where possible:
+
+- **go-cli**: run `go test ./...`
+- **rust-cli**: run `cargo test`
+- **dart-cli** and **flutter-gui**: run `dart test` or `flutter test`
+- **NetBeans**: run `mvn test`
+
+Some environments may need additional SDKs or build tools installed before tests can run.

--- a/dart-cli/test/dart_cli_test.dart
+++ b/dart-cli/test/dart_cli_test.dart
@@ -3,28 +3,28 @@ import 'package:test/test.dart';
 import '../bin/dart_cli.dart';
 
 void main() {
-  group('storage', () {
+  group('history', () {
     test('save and load', () async {
       var dir = Directory.systemTemp.createTempSync();
       var prev = Directory.current;
       Directory.current = dir;
-      var items = [Item(id: 1, prompt: 'p', response: 'r')];
-      await saveItems(items);
-      var loaded = await loadItems();
+      var messages = [Message(role: 'user', content: 'p')];
+      await saveHistory(messages);
+      var loaded = await loadHistory();
       expect(loaded.length, 1);
-      expect(loaded.first.prompt, 'p');
+      expect(loaded.first.content, 'p');
       Directory.current = prev;
     });
 
-    test('delete item', () {
-      var items = [
-        Item(id: 1, prompt: 'a', response: 'b'),
-        Item(id: 2, prompt: 'c', response: 'd')
-      ];
-      deleteItem(1, items);
-      expect(items.length, 1);
-      expect(items.first.id, 2);
-      expect(() => deleteItem(3, items), throwsException);
+    test('clear history', () async {
+      var dir = Directory.systemTemp.createTempSync();
+      var prev = Directory.current;
+      Directory.current = dir;
+      var messages = [Message(role: 'user', content: 'bye')];
+      await saveHistory(messages);
+      await clearHistory();
+      expect(File(historyFile).existsSync(), isFalse);
+      Directory.current = prev;
     });
   });
 }


### PR DESCRIPTION
## Summary
- fix Dart CLI test to match implementation
- ignore build folders and history files
- document how to run tests in each subproject

## Testing
- `go test ./...` in go-cli
- `cargo test` *(fails: Could not connect to server)*
- `dart test` *(fails: command not found)*
- `mvn test` *(fails: command not found)*