### PR TITLE
Fix Rust and Dart configs for CI

### DIFF
--- a/dart-cli/pubspec.yaml
+++ b/dart-cli/pubspec.yaml
@@ -2,7 +2,10 @@ name: dart_cli
 description: A simple Dart command line tool interacting with the OpenAI API.
 version: 0.1.0
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.17.0 <4.0.0'
 dependencies:
   args: ^2.4.0
   http: ^0.13.0
+
+dev_dependencies:
+  test: ^1.24.0

--- a/dart-cli/test/dart_cli_test.dart
+++ b/dart-cli/test/dart_cli_test.dart
@@ -4,27 +4,32 @@ import '../bin/dart_cli.dart';
 
 void main() {
   group('storage', () {
-    test('save and load', () async {
-      var dir = Directory.systemTemp.createTempSync();
-      var prev = Directory.current;
+    test('save and load history', () async {
+      final dir = Directory.systemTemp.createTempSync();
+      final prev = Directory.current;
       Directory.current = dir;
-      var items = [Item(id: 1, prompt: 'p', response: 'r')];
-      await saveItems(items);
-      var loaded = await loadItems();
+
+      final msgs = [Message(role: 'user', content: 'hello')];
+      await saveHistory(msgs);
+      final loaded = await loadHistory();
       expect(loaded.length, 1);
-      expect(loaded.first.prompt, 'p');
+      expect(loaded.first.role, 'user');
+      expect(loaded.first.content, 'hello');
+
       Directory.current = prev;
     });
 
-    test('delete item', () {
-      var items = [
-        Item(id: 1, prompt: 'a', response: 'b'),
-        Item(id: 2, prompt: 'c', response: 'd')
-      ];
-      deleteItem(1, items);
-      expect(items.length, 1);
-      expect(items.first.id, 2);
-      expect(() => deleteItem(3, items), throwsException);
+    test('clear history', () async {
+      final dir = Directory.systemTemp.createTempSync();
+      final prev = Directory.current;
+      Directory.current = dir;
+
+      final msgs = [Message(role: 'user', content: 'bye')];
+      await saveHistory(msgs);
+      await clearHistory();
+      expect(File(historyFile).existsSync(), isFalse);
+
+      Directory.current = prev;
     });
   });
 }

--- a/rust-cli/Cargo.toml
+++ b/rust-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-cli"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
## Summary
- update Rust edition
- loosen Dart SDK constraint
- add test package and correct CLI tests

## Testing
- `cargo test` *(fails: Could not connect to server)*
- `dart --version` *(fails: command not found)*