### PR TITLE
Add Perl CLI implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository contains multiple implementations that interact with the OpenAI 
 - `flutter-gui/` – A minimal Flutter application providing a GUI interface.
 - `dart-cli/` – A command line interface written in Dart.
 - `rust-cli/` – A command line interface written in Rust.
+- `perl-cli/` – A command line interface written in Perl.
 
 All CLI implementations share the same workflow: start an interactive `chat` session, inspect `history`, or `clear` the stored conversation. Each subfolder may provide additional documentation.
 
@@ -18,5 +19,6 @@ Each subproject provides unit tests where possible:
 - **rust-cli**: run `cargo test`
 - **dart-cli** and **flutter-gui**: run `dart test` or `flutter test`
 - **NetBeans**: run `mvn test`
+- **perl-cli**: run `prove -I . t`
 
 Some environments may need additional SDKs or build tools installed before tests can run.

--- a/perl-cli/README.md
+++ b/perl-cli/README.md
@@ -1,0 +1,16 @@
+# perl-cli
+
+A simple command line tool written in Perl for chatting with ChatGPT. It follows the same workflow as the other CLI examples and stores your conversation history locally. Set `OPENAI_API_KEY` before running.
+
+## Usage
+
+```bash
+# start an interactive conversation
+perl perl_cli.pl chat
+
+# show saved history
+perl perl_cli.pl history
+
+# clear saved history
+perl perl_cli.pl clear
+```

--- a/perl-cli/perl_cli.pl
+++ b/perl-cli/perl_cli.pl
@@ -1,0 +1,102 @@
+use strict;
+use warnings;
+use JSON::PP;
+use HTTP::Tiny;
+use File::Spec;
+
+our $history_file = 'history.json';
+
+sub load_history {
+    return [] unless -e $history_file;
+    open my $fh, '<', $history_file or return [];
+    local $/;
+    my $data = <$fh> // '';
+    close $fh;
+    return [] if $data =~ /^\s*$/;
+    my $json = JSON::PP->new->decode($data);
+    return $json;
+}
+
+sub save_history {
+    my ($msgs) = @_;
+    open my $fh, '>', $history_file or die $!;
+    print $fh JSON::PP->new->ascii->pretty->encode($msgs);
+    close $fh;
+}
+
+sub call_openai {
+    my ($msgs, $api_key) = @_;
+    my $ua = HTTP::Tiny->new();
+    my $body = JSON::PP->new->encode({ model => 'gpt-4o', messages => $msgs });
+    my $resp = $ua->post(
+        'https://api.openai.com/v1/chat/completions',
+        {
+            headers => {
+                'Authorization' => "Bearer $api_key",
+                'Content-Type'  => 'application/json',
+            },
+            content => $body,
+        }
+    );
+    die "API error: $resp->{status} $resp->{reason}" unless $resp->{success};
+    my $parsed = JSON::PP->new->decode($resp->{content});
+    die 'no choices returned' unless @{$parsed->{choices} || []};
+    return $parsed->{choices}[0]{message}{content};
+}
+
+sub chat {
+    my ($api_key) = @_;
+    my $history = load_history();
+    print "Enter 'exit' to quit.\n";
+    while (1) {
+        print '> ';
+        defined(my $line = <STDIN>) or last;
+        chomp $line;
+        my $text = $line;
+        $text =~ s/^\s+|\s+$//g;
+        last if $text eq 'exit' || $text eq 'quit';
+        push @$history, { role => 'user', content => $text };
+        my $reply = eval { call_openai($history, $api_key) };
+        if ($@) { warn "Error: $@"; last; }
+        print "$reply\n";
+        push @$history, { role => 'assistant', content => $reply };
+        save_history($history);
+    }
+}
+
+sub print_history {
+    my $history = load_history();
+    for my $m (@$history) {
+        print "$m->{role}: $m->{content}\n";
+    }
+}
+
+sub clear_history {
+    unlink $history_file if -e $history_file;
+}
+
+sub main {
+    if (!@ARGV) {
+        print "Usage: [chat|history|clear]\n";
+        return;
+    }
+    my $api_key = $ENV{OPENAI_API_KEY} // '';
+    if ($api_key eq '') {
+        print "OPENAI_API_KEY not set\n";
+        return;
+    }
+    my $cmd = shift @ARGV;
+    if ($cmd eq 'chat') {
+        chat($api_key);
+    } elsif ($cmd eq 'history') {
+        print_history();
+    } elsif ($cmd eq 'clear') {
+        clear_history();
+    } else {
+        print "Unknown command\n";
+    }
+}
+
+main() unless caller;
+
+1;

--- a/perl-cli/t/perl_cli.t
+++ b/perl-cli/t/perl_cli.t
@@ -1,0 +1,27 @@
+use strict;
+use warnings;
+use Test::More;
+use File::Temp qw(tempdir);
+use Cwd;
+use File::Spec;
+use FindBin;
+
+my $script = Cwd::abs_path(File::Spec->catfile($FindBin::Bin, '..', 'perl_cli.pl'));
+
+my $dir = tempdir(CLEANUP => 1);
+my $prev = getcwd();
+chdir $dir or die $!;
+
+require $script;
+our $history_file; # from script
+
+save_history([{ role => 'user', content => 'hi' }]);
+my $loaded = load_history();
+is_deeply($loaded, [{ role => 'user', content => 'hi' }], 'save and load history');
+
+clear_history();
+ok(!-e $main::history_file, 'history file removed');
+
+chdir $prev or die $!;
+
+done_testing();


### PR DESCRIPTION
## Summary
- add new `perl-cli` directory with a Perl implementation
- include a simple unit test for history management
- update root README to mention Perl CLI and how to run its tests

## Testing
- `go test ./...`
- `cargo test` *(fails: Could not connect to server)*
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `mvn test -q` *(fails: command not found)*
- `prove -I . t`