### PR TITLE
Improve and extend tests

### DIFF
--- a/NetBeans/src/test/java/me/davidcanhelp/chatgpt/ChatWindowTopComponentTest.java
+++ b/NetBeans/src/test/java/me/davidcanhelp/chatgpt/ChatWindowTopComponentTest.java
@@ -32,4 +32,39 @@ public class ChatWindowTopComponentTest {
             System.setProperty("user.home", orig);
         }
     }
+
+    @Test
+    public void testReadApiKeyFromFileSuccess() throws Exception {
+        ChatWindowTopComponent comp = new ChatWindowTopComponent();
+        String orig = System.getProperty("user.home");
+        Path tmp = Files.createTempDirectory("home");
+        java.nio.file.Path conf = tmp.resolve(".config/chatgpt");
+        Files.createDirectories(conf);
+        Files.writeString(conf.resolve("apikey.txt"), "secret");
+        System.setProperty("user.home", tmp.toString());
+        try {
+            Method m = ChatWindowTopComponent.class.getDeclaredMethod("readApiKeyFromFile");
+            m.setAccessible(true);
+            String key = (String) m.invoke(comp);
+            Assert.assertEquals("secret", key);
+        } finally {
+            System.setProperty("user.home", orig);
+        }
+    }
+
+    @Test
+    public void testWriteAndReadProperties() throws Exception {
+        ChatWindowTopComponent comp1 = new ChatWindowTopComponent();
+        java.lang.reflect.Field f = ChatWindowTopComponent.class.getDeclaredField("currentModel");
+        f.setAccessible(true);
+        f.set(comp1, "gpt-3.5-turbo");
+        java.util.Properties p = new java.util.Properties();
+        comp1.writeProperties(p);
+
+        ChatWindowTopComponent comp2 = new ChatWindowTopComponent();
+        comp2.readProperties(p);
+        f.setAccessible(true);
+        String model = (String) f.get(comp2);
+        Assert.assertEquals("gpt-3.5-turbo", model);
+    }
 }

--- a/clojure-cli/test/chat_cli/core_test.clj
+++ b/clojure-cli/test/chat_cli/core_test.clj
@@ -23,3 +23,16 @@
       (is (not (.exists (io/file core/history-file))))
       (finally
         (System/setProperty "user.dir" prev)))))
+
+(deftest load-history-missing-and-empty
+  (let [dir (java.nio.file.Files/createTempDirectory "hist3" (make-array java.nio.file.attribute.FileAttribute 0))
+        prev (System/getProperty "user.dir")]
+    (System/setProperty "user.dir" (.toString dir))
+    (try
+      ;; missing file
+      (is (= [] (core/load-history)))
+      ;; empty file
+      (spit core/history-file "")
+      (is (= [] (core/load-history)))
+      (finally
+        (System/setProperty "user.dir" prev)))))

--- a/dart-cli/test/dart_cli_test.dart
+++ b/dart-cli/test/dart_cli_test.dart
@@ -5,19 +5,20 @@ import '../bin/dart_cli.dart';
 void main() {
   group('history', () {
     test('save and load', () async {
-      var dir = Directory.systemTemp.createTempSync();
-      var prev = Directory.current;
+      final dir = Directory.systemTemp.createTempSync();
+      final prev = Directory.current;
       Directory.current = dir;
-      var messages = [Message(role: 'user', content: 'p')];
+
+      final messages = [Message(role: 'user', content: 'p')];
       await saveHistory(messages);
-      var loaded = await loadHistory();
+      final loaded = await loadHistory();
       expect(loaded.length, 1);
       expect(loaded.first.content, 'p');
+
       Directory.current = prev;
     });
 
     test('clear history', () async {
-
       final dir = Directory.systemTemp.createTempSync();
       final prev = Directory.current;
       Directory.current = dir;
@@ -26,13 +27,22 @@ void main() {
       await saveHistory(msgs);
       await clearHistory();
       expect(File(historyFile).existsSync(), isFalse);
-      var dir = Directory.systemTemp.createTempSync();
-      var prev = Directory.current;
+
+      Directory.current = prev;
+    });
+
+    test('load missing and empty', () async {
+      final dir = Directory.systemTemp.createTempSync();
+      final prev = Directory.current;
       Directory.current = dir;
-      var messages = [Message(role: 'user', content: 'bye')];
-      await saveHistory(messages);
-      await clearHistory();
-      expect(File(historyFile).existsSync(), isFalse);
+
+      var msgs = await loadHistory();
+      expect(msgs, isEmpty);
+
+      File(historyFile).writeAsStringSync('');
+      msgs = await loadHistory();
+      expect(msgs, isEmpty);
+
       Directory.current = prev;
     });
   });

--- a/go-cli/main_test.go
+++ b/go-cli/main_test.go
@@ -42,3 +42,31 @@ func TestClearHistory(t *testing.T) {
         t.Fatalf("history file should be removed")
     }
 }
+
+func TestLoadHistoryMissingAndEmpty(t *testing.T) {
+    dir := t.TempDir()
+    prev, _ := os.Getwd()
+    os.Chdir(dir)
+    defer os.Chdir(prev)
+
+    // missing file
+    msgs, err := loadHistory()
+    if err != nil {
+        t.Fatal(err)
+    }
+    if len(msgs) != 0 {
+        t.Fatalf("expected empty slice, got %v", msgs)
+    }
+
+    // empty file
+    if err := os.WriteFile(historyFile, []byte(""), 0644); err != nil {
+        t.Fatal(err)
+    }
+    msgs, err = loadHistory()
+    if err != nil {
+        t.Fatal(err)
+    }
+    if len(msgs) != 0 {
+        t.Fatalf("expected empty slice for empty file, got %v", msgs)
+    }
+}

--- a/perl-cli/t/perl_cli.t
+++ b/perl-cli/t/perl_cli.t
@@ -22,6 +22,15 @@ is_deeply($loaded, [{ role => 'user', content => 'hi' }], 'save and load history
 clear_history();
 ok(!-e $main::history_file, 'history file removed');
 
+# load history when file missing and empty
+my $msgs = load_history();
+is_deeply($msgs, [], 'load_history with missing file returns empty');
+
+open my $fh, '>', $main::history_file or die $!;
+close $fh;
+$msgs = load_history();
+is_deeply($msgs, [], 'load_history with empty file returns empty');
+
 chdir $prev or die $!;
 
 done_testing();

--- a/rust-cli/src/main.rs
+++ b/rust-cli/src/main.rs
@@ -159,4 +159,22 @@ mod tests {
 
         env::set_current_dir(prev).unwrap();
     }
+
+    #[test]
+    fn load_history_missing_and_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let prev = env::current_dir().unwrap();
+        env::set_current_dir(&dir).unwrap();
+
+        // missing file
+        let msgs = load_history().unwrap();
+        assert!(msgs.is_empty());
+
+        // empty file
+        std::fs::write(HISTORY_FILE, "").unwrap();
+        let msgs = load_history().unwrap();
+        assert!(msgs.is_empty());
+
+        env::set_current_dir(prev).unwrap();
+    }
 }


### PR DESCRIPTION
## Summary
- expand test coverage in multiple language implementations
- ensure history load handles missing and empty files
- add property persistence tests in NetBeans module

## Testing
- `go test ./go-cli/...`
- `prove -l perl-cli/t/perl_cli.t`
- ❌ `cargo test --manifest-path rust-cli/Cargo.toml` *(fails: could not connect to server)*