### PR TITLE
Fix flaky Rust tests

### DIFF
--- a/rust-cli/Cargo.toml
+++ b/rust-cli/Cargo.toml
@@ -10,3 +10,4 @@ reqwest = { version = "0.11", features = ["blocking", "json"] }
 
 [dev-dependencies]
 tempfile = "3"
+serial_test = "3"

--- a/rust-cli/src/main.rs
+++ b/rust-cli/src/main.rs
@@ -131,8 +131,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 mod tests {
     use super::*;
     use std::env;
+    use serial_test::serial;
 
     #[test]
+    #[serial]
     fn save_and_load_history() {
         let dir = tempfile::tempdir().unwrap();
         let prev = env::current_dir().unwrap();
@@ -147,6 +149,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn clear_history() -> Result<(), Box<dyn std::error::Error>> {
         let dir = tempfile::tempdir().unwrap();
         let prev = env::current_dir().unwrap();
@@ -162,6 +165,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn load_history_missing_and_empty() {
         let dir = tempfile::tempdir().unwrap();
         let prev = env::current_dir().unwrap();


### PR DESCRIPTION
## Summary
- prevent concurrency problems in Rust tests by running them serially

## Testing
- `cargo test` *(fails: could not fetch crates)*